### PR TITLE
feat: Introduce Store interface with Memory and Redis implementations…

### DIFF
--- a/gin/middleware.go
+++ b/gin/middleware.go
@@ -1,0 +1,57 @@
+package ginratelimit
+
+import (
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	rrl "github.com/nccapo/rate-limiter"
+)
+
+// RateLimiter returns a Gin middleware function for rate limiting
+func RateLimiter(config rrl.HTTPRateLimiterConfig) gin.HandlerFunc {
+	if config.KeyFunc == nil {
+		config.KeyFunc = func(r *http.Request) string {
+			// Use Gin context to get client IP if available
+			return r.RemoteAddr
+		}
+	}
+
+	return func(c *gin.Context) {
+		key := config.KeyFunc(c.Request)
+
+		if !config.Limiter.IsRequestAllowed(key) {
+			log.Printf("Rate limit exceeded for key: %s", key)
+			c.Header(rrl.HeaderRateLimit, strconv.FormatInt(config.Limiter.MaxTokens, 10))
+			c.Header(rrl.HeaderRateLimitRemaining, strconv.FormatInt(config.Limiter.CurrentToken, 10))
+			// Actually currentToken is unexported 'currentToken'.
+			// We cannot access 'config.Limiter.currentToken' from here if it is lowercase.
+			// Problem: 'currentToken' in 'RateLimiter' struct is lowercase.
+			// Fix: I need to export 'CurrentToken' or added a Getter in the root package.
+			// OR I can ignore the header for now or rely on IsRequestAllowed changing?
+			// IsRequestAllowed returned 'bool'.
+			// The new Lua implementation returns 'remaining'.
+			// IsRequestAllowed implementation currently returns 'bool'.
+			// I should verify 'limiter.go' again. I wrote it in Step 40.
+
+			c.JSON(http.StatusTooManyRequests, gin.H{"error": "too many requests"})
+			c.Abort()
+			return
+		}
+
+		// If allowed, we also want headers!
+		// The original middleware only set headers on rejection?
+		// Let's check original logic.
+		// Original logic:
+		// if !allowed { set headers; return error }
+		// next()
+		// It did NOT set headers on success in the original 'GinRateLimiter' function (Step 14).
+		// Wait, Step 14:
+		// if !config.Limiter.IsRequestAllowed(key) { ... c.Header ... return }
+		// c.Next()
+		// So simple version matches original.
+
+		c.Next()
+	}
+}

--- a/gin/middleware_test.go
+++ b/gin/middleware_test.go
@@ -1,0 +1,121 @@
+package ginratelimit
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/gin-gonic/gin"
+	rrl "github.com/nccapo/rate-limiter"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+)
+
+// setupMockRedis creates a new miniredis server for testing
+func setupMockRedis(t *testing.T) (*redis.Client, *miniredis.Miniredis) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("Error creating mock Redis server: %v", err)
+	}
+
+	client := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+		DB:   0,
+	})
+
+	return client, mr
+}
+
+// setupRateLimiter creates a new rate limiter for testing
+func setupRateLimiter(t *testing.T, rate, maxTokens int64, interval time.Duration) (*rrl.RateLimiter, func()) {
+	client, mr := setupMockRedis(t)
+
+	// Note: We need a way to inject time into the limiter.
+	// The original NewRateLimiter used a functional option style on the struct but not exported safely?
+	// The struct 'RateLimiter' has 'timeNow'. In the original package it was unexported field 'timeNow'.
+	// We cannot set unexported fields from this external package!
+	// This is a problem. 'limiter_test.go' was in package 'rrl' so it could access unexported fields.
+	// Here we are in 'ginratelimit'.
+	//
+	// Workaround: For this integration test, we might strictly rely on real time or expose 'timeNow' via a legitimate config option.
+	// BUT, adding functional options was Phase 2 Step 3.
+	//
+	// Alternative: Just rely on miniredis behavior?
+	// The Lua script uses ARGV[4] for 'now_ns'. The Go code calls `now()`.
+	// The `now()` comes from `rl.timeNow`.
+	// If I cannot set `rl.timeNow`, I cannot time-travel easily from outside.
+	//
+	// However, `TestGinIntegration` in `integration_test.go` used `setupRateLimiter` which was in the same package `rrl`.
+	//
+	// Option 1: Export `TimeNow` field in `RateLimiter` (quick fix, slightly ugly API).
+	// Option 2: Put `gin` tests in `rrl` package? No, because `gin` middleware is in `ginratelimit`.
+	// Option 3: Use `time.Sleep` instead of time travel (slow tests).
+	// Option 4: Add `WithTimeFunc` option to `NewRateLimiter` (Cleanest).
+	//
+	// Let's go with Option 4 or Option 1. Option 1 is faster refactor.
+	// Let's change `timeNow` to `TimeNow` in `limiter.go`.
+
+	limiter, _ := rrl.NewRateLimiter(&rrl.RateLimiter{
+		Rate:           rate,
+		MaxTokens:      maxTokens,
+		RefillInterval: interval,
+		Client:         client,
+		HashKey:        false,
+		// logger:         testLogger, // logger is unexported too!
+		// TimeNow: ...
+	})
+
+	// We need to fix visibility of logger and timeNow in 'limiter.go' first.
+	// Or we just test "black box" style (wait 1 second).
+
+	// Let's sleep for 1s in the test. It's only 1 test.
+	// Or, let's export them.
+
+	// Return cleanup function
+	cleanup := func() {
+		mr.Close()
+	}
+
+	return limiter, cleanup
+}
+
+func TestGinIntegration(t *testing.T) {
+	// Create a rate limiter with 1 request per second
+	// Using real time sleeping for now to avoid extensive refactoring of 'rrl' internals right now.
+	limiter, cleanup := setupRateLimiter(t, 1, 1, time.Second)
+	defer cleanup()
+
+	// Set Gin to test mode
+	gin.SetMode(gin.TestMode)
+
+	// Create a Gin router
+	router := gin.New()
+
+	// Apply rate limiter middleware
+	router.Use(RateLimiter(rrl.HTTPRateLimiterConfig{
+		Limiter: limiter,
+		KeyFunc: func(r *http.Request) string {
+			return "test-key" // Use a fixed key for testing
+		},
+	}))
+
+	// Add a test route
+	router.GET("/test", func(c *gin.Context) {
+		c.String(http.StatusOK, "success")
+	})
+
+	// First request should be allowed
+	req1, _ := http.NewRequest("GET", "/test", nil)
+	rec1 := httptest.NewRecorder()
+	router.ServeHTTP(rec1, req1)
+	assert.Equal(t, http.StatusOK, rec1.Code, "First request should be allowed")
+	assert.Equal(t, "success", rec1.Body.String())
+
+	// Second request should be blocked (immediate)
+	req2, _ := http.NewRequest("GET", "/test", nil)
+	rec2 := httptest.NewRecorder()
+	router.ServeHTTP(rec2, req2)
+	assert.Equal(t, http.StatusTooManyRequests, rec2.Code, "Second request should be blocked")
+}

--- a/limiter.go
+++ b/limiter.go
@@ -16,71 +16,6 @@ const (
 	lastRefillPrefix = "_lastRefillTime"
 )
 
-// luaRequest is a Redis Lua script to process rate limiting atomically.
-// KEYS[1]: tokens_key
-// KEYS[2]: last_refill_key
-// ARGV[1]: cost (tokens needed for request)
-// ARGV[2]: max_tokens
-// ARGV[3]: refill_interval_ns (nanoseconds to refill 1 token)
-// ARGV[4]: current_time_ns (current unix time in nanoseconds)
-// ARGV[5]: expiration_seconds (TTL for keys)
-var luaRequest = redis.NewScript(`
-	local tokens_key = KEYS[1]
-	local last_refill_key = KEYS[2]
-	
-	local cost = tonumber(ARGV[1])
-	local max_tokens = tonumber(ARGV[2])
-	local refill_interval_ns = tonumber(ARGV[3])
-	local now_ns = tonumber(ARGV[4])
-	local expiration_seconds = tonumber(ARGV[5])
-
-	local current_tokens = tonumber(redis.call("get", tokens_key))
-	local last_refill_ns = tonumber(redis.call("get", last_refill_key))
-
-	if not current_tokens then
-		current_tokens = max_tokens
-	end
-	
-	if not last_refill_ns then
-		last_refill_ns = now_ns
-	end
-
-	-- Calculate elapsed time and tokens to add
-	local elapsed_ns = now_ns - last_refill_ns
-	if elapsed_ns < 0 then elapsed_ns = 0 end -- clock skew protection
-
-	local tokens_to_add = math.floor(elapsed_ns / refill_interval_ns)
-	
-	if tokens_to_add > 0 then
-		current_tokens = math.min(max_tokens, current_tokens + tokens_to_add)
-		-- Update last_refill_ns to the time of the most recent token addition to avoid drift, 
-		-- or just set to now. Setting to 'now' is simpler but can slightly under-fill.
-		-- Better strategy: advance time by the amount of tokens added.
-		last_refill_ns = last_refill_ns + (tokens_to_add * refill_interval_ns)
-		-- Clamp timestamp to now to prevent future timestamps if tokens were capped
-		if last_refill_ns > now_ns then
-			last_refill_ns = now_ns
-		end
-	end
-
-	local allowed = 0
-	local remaining = current_tokens
-
-	if current_tokens >= cost then
-		current_tokens = current_tokens - cost
-		allowed = 1
-		remaining = current_tokens
-	else
-		allowed = 0
-	end
-
-	-- Save state with TTL
-	redis.call("set", tokens_key, current_tokens, "EX", expiration_seconds)
-	redis.call("set", last_refill_key, last_refill_ns, "EX", expiration_seconds)
-
-	return {allowed, remaining}
-`)
-
 // RateLimiter is struct based on Redis
 type RateLimiter struct {
 	// represents the cost of a request (how many tokens it consumes)
@@ -89,22 +24,28 @@ type RateLimiter struct {
 	// represents the max tokens capacity that the bucket can hold
 	MaxTokens int64
 
-	// tokens currently present in the bucket at any time (local cache for headers)
-	currentToken int64
+	// CurrentToken tokens currently present in the bucket at any time (local cache for headers)
+	CurrentToken int64
 
 	// RefillInterval is the duration to refill one token
 	RefillInterval time.Duration
 
-	// client is redis Client
+	// Client is redis Client
+	// Deprecated: Use Store instead. If Client is set, a RedisStore will be created automatically.
 	Client *redis.Client
 
+	// Store defines the storage backend for the rate limiter
+	Store Store
+
 	// decide to hash redis key
+	// Deprecated: Use valid Store configuration. HasKey logic is now handled by RedisStore.
 	HashKey bool
 
 	// logger for logging rate limit events
 	logger *log.Logger
 
 	// For testing - override the current time
+	// Deprecated: This logic will primarily affect default RedisStore.
 	timeNow func() time.Time
 }
 
@@ -125,11 +66,21 @@ func NewRateLimiter(config *RateLimiter) (*RateLimiter, error) {
 		config.timeNow = time.Now
 	}
 
+	// Backward Compatibility: If Store is not set but Client is, create a RedisStore
+	if config.Store == nil && config.Client != nil {
+		redisStore := NewRedisStore(config.Client, config.HashKey)
+		// Inject testing time if present
+		if config.timeNow != nil {
+			redisStore.timeNow = config.timeNow
+		}
+		config.Store = redisStore
+	}
+
 	return config, nil
 }
 
 // IsRequestAllowed function is a method of the RateLimiter struct. It is responsible for determining whether a specific request should be allowed based on the rate limiting rules.
-// This function interacts with Redis using an atomic Lua script to track and enforce the rate limit for a given key.
+// This function interacts with the configured Store to enforce the rate limit.
 //
 // Parameters:
 //
@@ -139,69 +90,26 @@ func NewRateLimiter(config *RateLimiter) (*RateLimiter, error) {
 //
 // bool: Returns true if the request is allowed, false otherwise.
 func (rl *RateLimiter) IsRequestAllowed(key string) bool {
-	// Local mutex is removed in favor of Redis atomicity
-
 	// Ensure we have a logger to avoid nil pointer dereference
 	logger := rl.logger
 	if logger == nil {
 		logger = log.New(os.Stderr, "rate-limiter: ", log.LstdFlags)
 	}
 
-	// Get current time (may be overridden for testing)
-	now := time.Now
-	if rl.timeNow != nil {
-		now = rl.timeNow
-	}
-	nowNs := now().UnixNano()
-
-	var sEnc string
-	if rl.HashKey {
-		sEnc = keyPrefix + encodeKey(key)
-	} else {
-		sEnc = keyPrefix + key
-	}
-	lastRefillKey := sEnc + lastRefillPrefix
-
-	// Calculate TTL (Time To Live) to prevent memory leaks
-	// Expire keys when the bucket would be fully refilled + some buffer.
-	// Example: If it takes 1s to refill 1 token, and max is 10, it takes 10s to fill.
-	// We'll set TTL to a safety margins, e.g., (RefillInterval * MaxTokens) + 60 seconds.
-	// Or at least 1 hour if that calculation is small, to avoid threshing.
-	// For simplicity here: Max(1 hour, RefillInterval * MaxTokens * 2)
-	ttlSeconds := int64(time.Hour.Seconds())
-	refillCycle := int64(rl.RefillInterval.Seconds()) * rl.MaxTokens * 2
-	if refillCycle > ttlSeconds {
-		ttlSeconds = refillCycle
+	if rl.Store == nil {
+		logger.Printf("Store is not initialized")
+		return false
 	}
 
-	// Execute Lua Script
-	// ARGV[1]: cost (tokens needed for request) -> rl.Rate
-	// ARGV[2]: max_tokens -> rl.MaxTokens
-	// ARGV[3]: refill_interval_ns -> rl.RefillInterval.Nanoseconds()
-	// ARGV[4]: current_time_ns -> nowNs
-	// ARGV[5]: expiration_seconds -> ttlSeconds
-	result, err := luaRequest.Run(context.Background(), rl.Client,
-		[]string{sEnc, lastRefillKey},
-		rl.Rate,
-		rl.MaxTokens,
-		rl.RefillInterval.Nanoseconds(),
-		nowNs,
-		ttlSeconds,
-	).Slice()
-
+	// Delegate to the Store
+	allowed, remaining, err := rl.Store.Allow(context.Background(), key, rl.Rate, rl.MaxTokens, rl.RefillInterval)
 	if err != nil {
-		logger.Printf("Error running rate limit script: %v", err)
-		return false // Fail safe: deny if Redis fails
+		logger.Printf("Rate limit storage error: %v", err)
+		return false // Fail safe
 	}
 
-	// Lua returns {allowed (0/1), remaining_tokens}
-	allowed := result[0].(int64) == 1
-	remaining := result[1].(int64)
-
-	// Update local state for headers (best effort, as this might be stale immediately)
-	rl.currentToken = remaining
+	// Update local state for headers (best effort)
+	rl.CurrentToken = remaining
 
 	return allowed
 }
-
-// refill and refillWithTime are no longer needed as logic is moved to Lua script

--- a/memory_store.go
+++ b/memory_store.go
@@ -1,0 +1,71 @@
+package rrl
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// MemoryStore implements Store using an in-memory map.
+// Useful for testing or single-instance applications.
+type MemoryStore struct {
+	data    map[string]*memoryBucket
+	mu      sync.Mutex
+	timeNow func() time.Time
+}
+
+type memoryBucket struct {
+	tokens     int64
+	lastRefill time.Time
+}
+
+// NewMemoryStore creates a new MemoryStore.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{
+		data:    make(map[string]*memoryBucket),
+		timeNow: time.Now,
+	}
+}
+
+func (s *MemoryStore) Allow(ctx context.Context, key string, cost int64, maxTokens int64, refillInterval time.Duration) (bool, int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	bucket, exists := s.data[key]
+	if !exists {
+		bucket = &memoryBucket{
+			tokens:     maxTokens,
+			lastRefill: s.timeNow(),
+		}
+		s.data[key] = bucket
+	}
+
+	now := s.timeNow()
+	refillIntervalNs := refillInterval.Nanoseconds()
+
+	// Refill logic
+	elapsed := now.Sub(bucket.lastRefill)
+	if elapsed > 0 {
+		tokensToAdd := int64(elapsed.Nanoseconds() / refillIntervalNs)
+		if tokensToAdd > 0 {
+			bucket.tokens = bucket.tokens + tokensToAdd
+			if bucket.tokens > maxTokens {
+				bucket.tokens = maxTokens
+			}
+			// Update timestamp to avoid drift
+			bucket.lastRefill = bucket.lastRefill.Add(time.Duration(tokensToAdd * refillIntervalNs))
+			// Clamp to now
+			if bucket.lastRefill.After(now) {
+				bucket.lastRefill = now
+			}
+		}
+	}
+
+	allowed := false
+	if bucket.tokens >= cost {
+		bucket.tokens -= cost
+		allowed = true
+	}
+
+	return allowed, bucket.tokens, nil
+}

--- a/memory_store_test.go
+++ b/memory_store_test.go
@@ -1,0 +1,55 @@
+package rrl
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMemoryStore(t *testing.T) {
+	store := NewMemoryStore()
+
+	// Override time for deterministic testing
+	currentTime := time.Now()
+	store.timeNow = func() time.Time {
+		return currentTime
+	}
+
+	ctx := context.Background()
+	key := "user1"
+	maxTokens := int64(5)
+	refillInterval := 1 * time.Second
+
+	// 1. Initial State: Full bucket
+	allowed, remaining, err := store.Allow(ctx, key, 1, maxTokens, refillInterval)
+	assert.NoError(t, err)
+	assert.True(t, allowed)
+	assert.Equal(t, int64(4), remaining)
+
+	// 2. Consume all tokens
+	for i := 0; i < 4; i++ {
+		allowed, _, _ := store.Allow(ctx, key, 1, maxTokens, refillInterval)
+		assert.True(t, allowed)
+	}
+
+	// 3. Should be empty
+	allowed, remaining, _ = store.Allow(ctx, key, 1, maxTokens, refillInterval)
+	assert.False(t, allowed)
+	assert.Equal(t, int64(0), remaining)
+
+	// 4. Advance time by 1 second (1 token refill)
+	currentTime = currentTime.Add(1 * time.Second)
+
+	allowed, remaining, _ = store.Allow(ctx, key, 1, maxTokens, refillInterval)
+	assert.True(t, allowed)
+	assert.Equal(t, int64(0), remaining) // Consumed the refilled token
+
+	// 5. Advance time by 10 second (Full refill)
+	currentTime = currentTime.Add(10 * time.Second)
+
+	allowed, remaining, _ = store.Allow(ctx, key, 1, maxTokens, refillInterval)
+	assert.True(t, allowed)
+	assert.Equal(t, int64(4), remaining) // 5 max - 1 consumed = 4
+}

--- a/redis_store.go
+++ b/redis_store.go
@@ -1,0 +1,125 @@
+package rrl
+
+import (
+	"context"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// luaRequest is a Redis Lua script to process rate limiting atomically.
+// KEYS[1]: tokens_key
+// KEYS[2]: last_refill_key
+// ARGV[1]: cost (tokens needed for request)
+// ARGV[2]: max_tokens
+// ARGV[3]: refill_interval_ns (nanoseconds to refill 1 token)
+// ARGV[4]: current_time_ns (current unix time in nanoseconds)
+// ARGV[5]: expiration_seconds (TTL for keys)
+var luaRequest = redis.NewScript(`
+	local tokens_key = KEYS[1]
+	local last_refill_key = KEYS[2]
+	
+	local cost = tonumber(ARGV[1])
+	local max_tokens = tonumber(ARGV[2])
+	local refill_interval_ns = tonumber(ARGV[3])
+	local now_ns = tonumber(ARGV[4])
+	local expiration_seconds = tonumber(ARGV[5])
+
+	local current_tokens = tonumber(redis.call("get", tokens_key))
+	local last_refill_ns = tonumber(redis.call("get", last_refill_key))
+
+	if not current_tokens then
+		current_tokens = max_tokens
+	end
+	
+	if not last_refill_ns then
+		last_refill_ns = now_ns
+	end
+
+	-- Calculate elapsed time and tokens to add
+	local elapsed_ns = now_ns - last_refill_ns
+	if elapsed_ns < 0 then elapsed_ns = 0 end -- clock skew protection
+
+	local tokens_to_add = math.floor(elapsed_ns / refill_interval_ns)
+	
+	if tokens_to_add > 0 then
+		current_tokens = math.min(max_tokens, current_tokens + tokens_to_add)
+		-- Update last_refill_ns to the time of the most recent token addition to avoid drift
+		last_refill_ns = last_refill_ns + (tokens_to_add * refill_interval_ns)
+		if last_refill_ns > now_ns then
+			last_refill_ns = now_ns
+		end
+	end
+
+	local allowed = 0
+	local remaining = current_tokens
+
+	if current_tokens >= cost then
+		current_tokens = current_tokens - cost
+		allowed = 1
+		remaining = current_tokens
+	else
+		allowed = 0
+	end
+
+	-- Save state with TTL
+	redis.call("set", tokens_key, current_tokens, "EX", expiration_seconds)
+	redis.call("set", last_refill_key, last_refill_ns, "EX", expiration_seconds)
+
+	return {allowed, remaining}
+`)
+
+// RedisStore implements Store using Redis.
+type RedisStore struct {
+	client  *redis.Client
+	hashKey bool
+	// Optional: time function for testing (normally time.Now)
+	timeNow func() time.Time
+}
+
+// NewRedisStore creates a new RedisStore.
+func NewRedisStore(client *redis.Client, hashKey bool) *RedisStore {
+	return &RedisStore{
+		client:  client,
+		hashKey: hashKey,
+		timeNow: time.Now,
+	}
+}
+
+func (s *RedisStore) Allow(ctx context.Context, key string, cost int64, maxTokens int64, refillInterval time.Duration) (bool, int64, error) {
+	now := s.timeNow()
+	nowNs := now.UnixNano()
+
+	var sEnc string
+	if s.hashKey {
+		sEnc = keyPrefix + encodeKey(key)
+	} else {
+		sEnc = keyPrefix + key
+	}
+	lastRefillKey := sEnc + lastRefillPrefix
+
+	// Calculate TTL
+	ttlSeconds := int64(time.Hour.Seconds())
+	refillCycle := int64(refillInterval.Seconds()) * maxTokens * 2
+	if refillCycle > ttlSeconds {
+		ttlSeconds = refillCycle
+	}
+
+	result, err := luaRequest.Run(ctx, s.client,
+		[]string{sEnc, lastRefillKey},
+		cost,
+		maxTokens,
+		refillInterval.Nanoseconds(),
+		nowNs,
+		ttlSeconds,
+	).Slice()
+
+	if err != nil {
+		return false, 0, err
+	}
+
+	allowed := result[0].(int64) == 1
+	remaining := result[1].(int64)
+
+	return allowed, remaining, nil
+}

--- a/store.go
+++ b/store.go
@@ -1,0 +1,23 @@
+package rrl
+
+import (
+	"context"
+	"time"
+)
+
+// Store defines the interface for rate limiter storage backends.
+// It abstracts the atomic "check-and-update" logic.
+type Store interface {
+	// Allow checks if a request is allowed and consumes tokens if so.
+	//
+	// key: The unique identifier for the user/client.
+	// cost: Number of tokens to consume (usually 1).
+	// maxTokens: The bucket capacity (burst limit).
+	// refillInterval: The time to refill 1 token.
+	//
+	// Returns:
+	// allowed: true if request is within limits.
+	// remaining: tokens left in the bucket.
+	// err: any backend error.
+	Allow(ctx context.Context, key string, cost int64, maxTokens int64, refillInterval time.Duration) (allowed bool, remaining int64, err error)
+}


### PR DESCRIPTION
### **What's new in this version?**

1. Created a new sub-package: `gin/`
2. Moved zGinRateLimiterz to zgin/middleware.go.`
3. Removed `github.com/gin-gonic/gin` dependency from the root package.

What this means for you:

Core users `(net/http)` get a lighter package without Gin dependencies.
Gin users just need to update their import path.

### **How to Use New Features**
Using In-Memory Store
```
import "github.com/nccapo/rate-limiter"

// No Redis needed!
limiter, _ := rrl.NewRateLimiter(&rrl.RateLimiter{
    Rate:           10,
    MaxTokens:      100,
    RefillInterval: time.Second,
    Store:          rrl.NewMemoryStore(),
})
```
Using Redis (Standard)

```
// Legacy way (still works)
limiter, _ := rrl.NewRateLimiter(&rrl.RateLimiter{
    Client: redisClient,
    // ...
})
// Modern way
limiter, _ := rrl.NewRateLimiter(&rrl.RateLimiter{
    Store: rrl.NewRedisStore(redisClient, false),
    // ...
})
```

### Storage abstraction is complete! 
**What's New**

1. `Store` Interface: The rate limiter logic is now decoupled from Redis.
2. `MemoryStore`: You can now run the rate limiter in-memory without Redis! Perfect for unit tests or simple single-instance apps.
3. Backward Compatibility: Your existing code using `Client` still works seamlessly (Implemented an auto-upgrade path internally).