### PR TITLE
feat: Implement client-side blocking with `Wait` method, add `WithStr…

### DIFF
--- a/memory_store_test.go
+++ b/memory_store_test.go
@@ -23,33 +23,34 @@ func TestMemoryStore(t *testing.T) {
 	refillInterval := 1 * time.Second
 
 	// 1. Initial State: Full bucket
-	allowed, remaining, err := store.Allow(ctx, key, 1, maxTokens, refillInterval)
+	allowed, remaining, _, err := store.Allow(ctx, key, 1, maxTokens, refillInterval)
 	assert.NoError(t, err)
 	assert.True(t, allowed)
 	assert.Equal(t, int64(4), remaining)
 
 	// 2. Consume all tokens
 	for i := 0; i < 4; i++ {
-		allowed, _, _ := store.Allow(ctx, key, 1, maxTokens, refillInterval)
+		allowed, _, _, _ := store.Allow(ctx, key, 1, maxTokens, refillInterval)
 		assert.True(t, allowed)
 	}
 
 	// 3. Should be empty
-	allowed, remaining, _ = store.Allow(ctx, key, 1, maxTokens, refillInterval)
+	allowed, remaining, retryAfter, _ := store.Allow(ctx, key, 1, maxTokens, refillInterval)
 	assert.False(t, allowed)
 	assert.Equal(t, int64(0), remaining)
+	assert.True(t, retryAfter > 0) // Should have a wait time
 
 	// 4. Advance time by 1 second (1 token refill)
 	currentTime = currentTime.Add(1 * time.Second)
 
-	allowed, remaining, _ = store.Allow(ctx, key, 1, maxTokens, refillInterval)
+	allowed, remaining, _, _ = store.Allow(ctx, key, 1, maxTokens, refillInterval)
 	assert.True(t, allowed)
 	assert.Equal(t, int64(0), remaining) // Consumed the refilled token
 
 	// 5. Advance time by 10 second (Full refill)
 	currentTime = currentTime.Add(10 * time.Second)
 
-	allowed, remaining, _ = store.Allow(ctx, key, 1, maxTokens, refillInterval)
+	allowed, remaining, _, _ = store.Allow(ctx, key, 1, maxTokens, refillInterval)
 	assert.True(t, allowed)
 	assert.Equal(t, int64(4), remaining) // 5 max - 1 consumed = 4
 }

--- a/store.go
+++ b/store.go
@@ -18,6 +18,7 @@ type Store interface {
 	// Returns:
 	// allowed: true if request is within limits.
 	// remaining: tokens left in the bucket.
+	// retryAfter: time to wait before the request would be allowed (if not allowed).
 	// err: any backend error.
-	Allow(ctx context.Context, key string, cost int64, maxTokens int64, refillInterval time.Duration) (allowed bool, remaining int64, err error)
+	Allow(ctx context.Context, key string, cost int64, maxTokens int64, refillInterval time.Duration) (allowed bool, remaining int64, retryAfter time.Duration, err error)
 }


### PR DESCRIPTION
### **What's new?**

1. **Blocking `Wait(ctx, key)`**: You can now throttle outgoing requests easily. 
```
// Will sleep automatically if limit reached
err := limiter.Wait(ctx, "my-worker")
```
2. **Strict Pacing**: Need smooth traffic without bursts?
```
// Forces MaxTokens=1, behaving like a leaky bucket
rrl.NewRateLimiter(..., rrl.WithStrictPacing())
```
3. **Unlimited**: Helper for tests.
```
limiter := rrl.NewUnlimited()
```
 Implemented the 3 advanced features effectively creating a hybrid that offers the best of both `(blocking/pacing)` and our original design `(distributed/bursts)`.