### PR TITLE
feat: implement Redis sliding window rate limiter and circuit breaker…

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,31 @@ limiter, _ := rrl.NewRateLimiter(
 )
 ```
 
-### 📋 Available Options
+### 6. Sliding Window Algorithm (Strict) 🪟
+
+If you need a strict limit (e.g., "Max 100 requests" in "Last 60 seconds") without the "bursts" allowed by the Token Bucket algorithm, use the **Sliding Window** store.
+
+*   **Logic**: Uses Redis Sorted Sets (`ZSET`) to track individual request timestamps.
+*   **Precision**: Extremely precise but uses more Redis memory (stores one entry per request).
+*   **Window Size**: Calculated as `MaxTokens * RefillInterval`.
+    *   Example: `MaxTokens(100)` and `RefillInterval(1s)` -> Window = 100 seconds.
+    *   Example: `MaxTokens(10)`, `RefillInterval(1m)` -> Window = 10 minutes.
+
+```go
+// 1. Create Sliding Window Store
+store := rrl.NewRedisSlidingWindowStore(rdb, true)
+
+// 2. Create Limiter
+// Limit: 5 requests. Window: 5 seconds.
+// How? MaxTokens=5. RefillInterval=1s.
+limiter, _ := rrl.NewRateLimiter(
+    rrl.WithMaxTokens(5),
+    rrl.WithRefillInterval(time.Second),
+    rrl.WithStore(store), 
+)
+```
+
+## 🤝 Contributing
 
 | Option | Description | Default |
 |--------|-------------|---------|

--- a/circuit_breaker_store.go
+++ b/circuit_breaker_store.go
@@ -1,0 +1,125 @@
+package rrl
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// State represents the state of the circuit breaker.
+type State int
+
+const (
+	StateClosed State = iota
+	StateOpen
+	StateHalfOpen
+)
+
+// CircuitBreakerConfig holds configuration for the circuit breaker.
+type CircuitBreakerConfig struct {
+	// Threshold is the number of consecutive errors to open the circuit.
+	Threshold int64
+	// Timeout is the duration to wait before trying to close the circuit (Half-Open).
+	Timeout time.Duration
+	// FallbackAllow determines if we should allow requests (true) or block them (false) when Open.
+	// Default: false (Block/Fail Fast).
+	FallbackAllow bool
+}
+
+// CircuitBreakerStore wraps another Store and prevents calls when the underlying Store fails repeatedly.
+type CircuitBreakerStore struct {
+	backend Store
+	config  CircuitBreakerConfig
+
+	mu          sync.Mutex
+	state       State
+	failures    int64
+	lastFailure time.Time
+
+	// timeNow allows mocking time for tests
+	timeNow func() time.Time
+}
+
+// NewCircuitBreakerStore creates a new CircuitBreakerStore.
+func NewCircuitBreakerStore(backend Store, config CircuitBreakerConfig) *CircuitBreakerStore {
+	if config.Threshold <= 0 {
+		config.Threshold = 5
+	}
+	if config.Timeout <= 0 {
+		config.Timeout = 5 * time.Second
+	}
+
+	return &CircuitBreakerStore{
+		backend: backend,
+		config:  config,
+		state:   StateClosed,
+		timeNow: time.Now,
+	}
+}
+
+// Allow delegates to the backend store, implementing the Circuit Breaker logic.
+func (s *CircuitBreakerStore) Allow(ctx context.Context, key string, cost int64, maxTokens int64, refillInterval time.Duration) (bool, int64, time.Duration, error) {
+	s.mu.Lock()
+	state := s.state
+
+	// Check if we need to switch from Open to Half-Open
+	if state == StateOpen {
+		if s.timeNow().Sub(s.lastFailure) > s.config.Timeout {
+			state = StateHalfOpen
+			s.state = StateHalfOpen
+		}
+	}
+	s.mu.Unlock()
+
+	// Logic based on state
+	switch state {
+	case StateOpen:
+		// Fail Fast
+		if s.config.FallbackAllow {
+			return true, maxTokens, 0, nil // Degraded mode: Allow everything (risky?) or just bypass?
+			// Usually rate limiter fallback -> Allow Open (= No Limit) or Block (= Total Outage).
+			// Let's assume user wants to 'Fail Open' (Allow) to keep service running, OR 'Fail Closed' (Block) to protect downstream.
+			// Configurable.
+		}
+		// Return error or explicit "blocked by circuit breaker"
+		return false, 0, s.config.Timeout, errors.New("circuit breaker open")
+
+	case StateHalfOpen:
+		// Attempt one request (Probe)
+		// We could use a lock to ensure only 1 probe, but simple optimization is: just let it pass.
+		// If it succeeds, Close. If fail, Re-Open.
+		return s.attemptRequest(ctx, key, cost, maxTokens, refillInterval)
+
+	case StateClosed:
+		// Normal operation
+		return s.attemptRequest(ctx, key, cost, maxTokens, refillInterval)
+	}
+
+	return false, 0, 0, nil
+}
+
+func (s *CircuitBreakerStore) attemptRequest(ctx context.Context, key string, cost int64, maxTokens int64, refillInterval time.Duration) (bool, int64, time.Duration, error) {
+	allowed, remaining, retryAfter, err := s.backend.Allow(ctx, key, cost, maxTokens, refillInterval)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err != nil {
+		s.failures++
+		s.lastFailure = s.timeNow()
+
+		if s.state == StateHalfOpen || s.failures >= s.config.Threshold {
+			s.state = StateOpen
+		}
+		return allowed, remaining, retryAfter, err
+	}
+
+	// Success! Reset.
+	if s.state == StateHalfOpen || s.failures > 0 {
+		s.failures = 0
+		s.state = StateClosed
+	}
+
+	return allowed, remaining, retryAfter, nil
+}

--- a/circuit_breaker_store_test.go
+++ b/circuit_breaker_store_test.go
@@ -1,0 +1,101 @@
+package rrl
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// MockStore for testing circuit breaker
+type FailStore struct {
+	shouldFail bool
+}
+
+func (f *FailStore) Allow(ctx context.Context, key string, cost int64, maxTokens int64, refillInterval time.Duration) (bool, int64, time.Duration, error) {
+	if f.shouldFail {
+		return false, 0, 0, errors.New("backend connection lost")
+	}
+	return true, 10, 0, nil
+}
+
+func TestCircuitBreakerStore(t *testing.T) {
+	mock := &FailStore{shouldFail: false}
+
+	// Config: Trip after 2 failures, 1s timeout
+	config := CircuitBreakerConfig{
+		Threshold: 2,
+		Timeout:   1 * time.Second,
+	}
+
+	cb := NewCircuitBreakerStore(mock, config)
+
+	// Mock time
+	start := time.Now()
+	cb.timeNow = func() time.Time { return start }
+
+	ctx := context.Background()
+
+	// 1. Success (Closed)
+	allowed, _, _, err := cb.Allow(ctx, "k", 1, 1, time.Second)
+	assert.NoError(t, err)
+	assert.True(t, allowed)
+	assert.Equal(t, StateClosed, cb.state)
+
+	// 2. Failure 1 (Closed)
+	mock.shouldFail = true
+	_, _, _, err = cb.Allow(ctx, "k", 1, 1, time.Second)
+	assert.Error(t, err)
+	assert.Equal(t, int64(1), cb.failures)
+	assert.Equal(t, StateClosed, cb.state)
+
+	// 3. Failure 2 (Trip -> Open)
+	_, _, _, err = cb.Allow(ctx, "k", 1, 1, time.Second)
+	assert.Error(t, err)
+	assert.Equal(t, StateOpen, cb.state)
+
+	// 4. Open State (Fail Fast)
+	// Even if backend fixes itself, CB blocks calls
+	mock.shouldFail = false
+	allowed, _, _, err = cb.Allow(ctx, "k", 1, 1, time.Second)
+	assert.Error(t, err, "Should error fast")
+	assert.Equal(t, "circuit breaker open", err.Error())
+	assert.False(t, allowed)
+
+	// 5. Half-Open (After Timeout)
+	// Advance time by 1.1s
+	cb.timeNow = func() time.Time { return start.Add(1100 * time.Millisecond) }
+
+	// Probe Request (Should succeed now since mock.shouldFail=false)
+	allowed, _, _, err = cb.Allow(ctx, "k", 1, 1, time.Second)
+	assert.NoError(t, err)
+	assert.True(t, allowed)
+
+	// Should be Closed again
+	assert.Equal(t, StateClosed, cb.state)
+	assert.Equal(t, int64(0), cb.failures)
+}
+
+func TestCircuitBreakerStore_Fallback(t *testing.T) {
+	mock := &FailStore{shouldFail: true}
+
+	// Config: FallbackAllow = true (Fail Open)
+	config := CircuitBreakerConfig{
+		Threshold:     1,
+		Timeout:       time.Second,
+		FallbackAllow: true,
+	}
+
+	cb := NewCircuitBreakerStore(mock, config)
+
+	// Trip it
+	cb.Allow(context.Background(), "k", 1, 1, time.Second) // Fail 1
+	assert.Equal(t, StateOpen, cb.state)
+
+	// Now call again. Should trigger Fallback (Allow=true, No Error)
+	allowed, _, _, err := cb.Allow(context.Background(), "k", 1, 1, time.Second)
+	assert.NoError(t, err)
+	assert.True(t, allowed, "Should be allowed by fallback")
+}

--- a/redis_sliding_window_store.go
+++ b/redis_sliding_window_store.go
@@ -1,0 +1,148 @@
+package rrl
+
+import (
+	"context"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// luaSlidingWindow handles the sliding window logic atomically using sorted sets.
+// KEYS[1]: zset_key
+// ARGV[1]: window_size_ns (total duration of the window)
+// ARGV[2]: max_requests (limit)
+// ARGV[3]: now_ns (current time)
+// ARGV[4]: cost
+// ARGV[5]: expiration_seconds (TTL)
+var luaSlidingWindow = redis.NewScript(`
+	local key = KEYS[1]
+	local window_size_ns = tonumber(ARGV[1])
+	local limit = tonumber(ARGV[2])
+	local now_ns = tonumber(ARGV[3])
+	local cost = tonumber(ARGV[4])
+	local ttl = tonumber(ARGV[5])
+
+	-- 1. Remove entries older than (now - window_size)
+	local window_start = now_ns - window_size_ns
+	redis.call("ZREMRANGEBYSCORE", key, "-inf", window_start)
+
+	-- 2. Count current entries
+	local current_count = redis.call("ZCARD", key)
+	
+	local allowed = 0
+	local remaining = 0
+	local retry_after_ns = 0
+
+	if current_count + cost <= limit then
+		-- ALLOWED
+		allowed = 1
+		remaining = limit - (current_count + cost)
+		
+		-- Add 'cost' members. We need unique members if they have same timestamp.
+		-- ZADD supports multiple members. We'll verify cost > 0.
+		for i = 1, cost do
+			-- Use a tiny suffix or unique implementation detail if needed.
+			-- Ideally we just use member = timestamp. But duplicates are overwritten in ZSET.
+			-- Trick: value = timestamp + micro-counter? or just use unique strings?
+			-- Simplification: "value" = "timestamp_micro_random"
+			-- Lua doesn't have good random. 
+			-- ALTERNATIVE: Use just 1 entry with 'score=timestamp' and 'member' is unique?
+			-- Actually for rate limiting, we just need to count.
+			-- Let's append index to 'now_ns' string for member uniqueness.
+			local member = tostring(now_ns) .. ":" .. i
+			redis.call("ZADD", key, now_ns, member)
+		end
+	else
+		-- BLOCKED
+		allowed = 0
+		remaining = limit - current_count
+		if remaining < 0 then remaining = 0 end
+
+		-- Calculate retry_after.
+		-- We need to wait until the Oldest timestamp expires.
+		-- Fetch the oldest entry (smallest score).
+		local oldest_entries = redis.call("ZRANGE", key, 0, 0, "WITHSCORES")
+		if #oldest_entries > 1 then
+			local oldest_score = tonumber(oldest_entries[2]) -- [1]=member, [2]=score
+			-- Time when this oldest entry falls out of window = oldest_score + window_size
+			-- Retry after = (oldest_score + window_size) - now
+			local available_at = oldest_score + window_size_ns
+			if available_at > now_ns then
+				retry_after_ns = available_at - now_ns
+			end
+		end
+	end
+
+	-- Refresh TTL
+	redis.call("EXPIRE", key, ttl)
+
+	return {allowed, remaining, retry_after_ns}
+`)
+
+// RedisSlidingWindowStore implements Store using Redis ZSETs for strict sliding window.
+type RedisSlidingWindowStore struct {
+	client  redis.UniversalClient
+	hashKey bool
+	timeNow func() time.Time
+}
+
+// NewRedisSlidingWindowStore creates a new store for strict rolling windows.
+func NewRedisSlidingWindowStore(client redis.UniversalClient, hashKey bool) *RedisSlidingWindowStore {
+	return &RedisSlidingWindowStore{
+		client:  client,
+		hashKey: hashKey,
+		timeNow: time.Now,
+	}
+}
+
+func (s *RedisSlidingWindowStore) Allow(ctx context.Context, key string, cost int64, maxTokens int64, refillInterval time.Duration) (bool, int64, time.Duration, error) {
+	now := s.timeNow()
+	nowNs := now.UnixNano()
+
+	var sEnc string
+	if s.hashKey {
+		sEnc = keyPrefix + encodeKey(key) + ":sw" // Suffix to distinguish from TokenBucket
+	} else {
+		sEnc = keyPrefix + key + ":sw"
+	}
+
+	// Logic Mapping:
+	// TokenBucket: Capacity=maxTokens, Rate=1/refillInterval
+	// SlidingWindow: Limit=maxTokens, WindowSize=maxTokens*refillInterval ?
+	// Example: Rate=10, Max=100 (Burst). Refill=100ms.
+	// We want strict window.
+	// Usually strict window is defined as "Limit N per Window W".
+	// If user passes `WithMaxTokens(100)` and `WithRefillInterval(time.Second)`:
+	// Interpretation A: 100 reqs per 100 seconds? (1 Token refill = 1 sec).
+	// Interpretation B: RefillInterval is irrelevant/forced?
+
+	// Convention we agreed: WindowSize = Limit * RefillInterval.
+	// If Limit=10, Refill=1s (1 req/s average). Window = 10s.
+	// "10 requests per 10 seconds". This matches the average rate.
+	windowSizeNs := maxTokens * refillInterval.Nanoseconds()
+
+	// TTL: Window Size + Buffer (e.g. 1 min or 2x window)
+	ttlSeconds := int64(time.Duration(windowSizeNs).Seconds()) + 60
+	if ttlSeconds < 60 {
+		ttlSeconds = 60
+	}
+
+	result, err := luaSlidingWindow.Run(ctx, s.client,
+		[]string{sEnc},
+		windowSizeNs,
+		maxTokens, // Limit
+		nowNs,
+		cost,
+		ttlSeconds,
+	).Slice()
+
+	if err != nil {
+		return false, 0, 0, err
+	}
+
+	allowed := result[0].(int64) == 1
+	remaining := result[1].(int64)
+	retryAfterNs := result[2].(int64)
+
+	return allowed, remaining, time.Duration(retryAfterNs), nil
+}

--- a/redis_sliding_window_store_test.go
+++ b/redis_sliding_window_store_test.go
@@ -1,0 +1,80 @@
+package rrl
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedisSlidingWindowStore(t *testing.T) {
+	client, mr := setupRedisClient(t)
+	defer mr.Close()
+
+	store := NewRedisSlidingWindowStore(client, false)
+
+	// Deterministic time
+	start := time.Now()
+	store.timeNow = func() time.Time {
+		return start
+	}
+
+	ctx := context.Background()
+	key := "test-sliding"
+
+	// Config: 2 requests per 1 second.
+	// Limit (maxTokens) = 2.
+	// RefillInterval = 500ms.
+	// WindowSize = 2 * 500ms = 1s.
+	limit := int64(2)
+	refill := 500 * time.Millisecond
+
+	// 1. First Request: Allowed
+	allowed, remaining, _, err := store.Allow(ctx, key, 1, limit, refill)
+	assert.NoError(t, err)
+	assert.True(t, allowed)
+	assert.Equal(t, int64(1), remaining)
+
+	// 2. Second Request: Allowed
+	allowed, remaining, _, err = store.Allow(ctx, key, 1, limit, refill)
+	assert.True(t, allowed)
+	assert.Equal(t, int64(0), remaining) // 0 remaining
+
+	// 3. Third Request: Blocked (Limit reached within 1s window)
+	allowed, _, retryAfter, _ := store.Allow(ctx, key, 1, limit, refill)
+	assert.False(t, allowed)
+	assert.True(t, retryAfter > 0)
+	// Retry after should be ~1s (since first req was at 'start')
+	// Wait, retryAfter = (oldest + window) - now
+	// oldest = start. window = 1s. now = start.
+	// retry = 1s.
+	assert.InDelta(t, time.Second.Nanoseconds(), retryAfter.Nanoseconds(), float64(100*time.Millisecond))
+
+	// 4. Advance Time by 600ms.
+	// Window is [start-1s, start]. (Actually [now-1s, now])
+	// New Time: start + 0.6s.
+	// Window range: [-0.4s, 0.6s].
+	// Oldest req was at 0s. Still in window!
+	store.timeNow = func() time.Time {
+		return start.Add(600 * time.Millisecond)
+	}
+
+	allowed, _, _, _ = store.Allow(ctx, key, 1, limit, refill)
+	assert.False(t, allowed, "Should still be blocked because older requests are in the 1s window")
+
+	// 5. Advance Time by 1.1s (Total 1.1 from start)
+	// New Time: start + 1.1s.
+	// Window range: [0.1s, 1.1s].
+	// Oldest req was at 0s. 0s < 0.1s. So it drops out!
+	// Next req was at 0s too (we sent 2 at start). Both drop out?
+	store.timeNow = func() time.Time {
+		return start.Add(1100 * time.Millisecond)
+	}
+
+	allowed, remaining, _, _ = store.Allow(ctx, key, 1, limit, refill)
+	assert.True(t, allowed, "Should be allowed now that window slid past old requests")
+	// Since both previous drops happened at 0s, both are gone.
+	// We sent 1 new one. Count is 1. Remaining should be 1.
+	assert.Equal(t, int64(1), remaining)
+}


### PR DESCRIPTION
### **What's new?**
**Sliding Window Protocol is now implemented!** 🪟 This store provides strict rolling window limits (e.g., "Exactly 5 requests in the last 10 seconds").
**Behavior:**

- Uses Redis Sorted Sets (ZSET).
- Removes old requests accurately (no "burst at the edge of the minute" issues).
- Usage:
```
store := rrl.NewRedisSlidingWindowStore(rdb, true)

// 5 requests per 10 seconds (MaxTokens=5, Refill=2s)
limiter, _ := rrl.NewRateLimiter(
    rrl.WithMaxTokens(5),
    rrl.WithRefillInterval(2 * time.Second),
    rrl.WithStore(store), 
)
```

**Implemented the Circuit Breaker Integration!** ⚡
This wrapper store makes your rate limiter resilient to backend failures.

How it works:

- Closed (Normal): Requests go through to Redis.
- Tripped (Backend Down): After N consecutive errors, it "Opens".
- Open (Fail Fast): All requests fail locally (or pass if `FallbackAllow=true`) for a timeout period, protecting your app from hanging on a dead Redis.
- Recovery: It automatically probes and closes the circuit when Redis recovers.
```
cbStore := rrl.NewCircuitBreakerStore(redisStore, config)
```

