### PR TITLE
fix: data race in RateLimiter, fix circuit breaker concurrency flaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ A robust, thread-safe, and distributed rate limiter for Go, designed for high-th
     *   Standard `net/http` middleware included.
     *   Specialized `Gin` middleware available in a sub-package.
 *   **🧠 Memory Safe**: Automatic TTL management for Redis keys prevents zombie data and memory leaks.
+*   **🆕 Thread-Safe**: Fixed critical race conditions in v0.7.4. Default `RateLimiter` is now fully atomic for concurrent use.
+
+## 🆕 What's New in v0.7.5
+
+*   **Critical Fix**: Resolved a data race in `RateLimiter` where header generation was using shared state. Now uses a thread-safe `Allow(ctx, key)` API.
+*   **Circuit Breaker**: Fixed a concurrency flaw in the "Half-Open" state. It now correctly allows only *one* probe request at a time, preventing backend overload.
+*   **API Update**: `IsRequestAllowed(key)` is **deprecated**. Please use `Allow(ctx, key)` which returns detailed metadata (`Remaining`, `RetryAfter`).
+*   **Performance**: Identified opportunity to optimize ID generation (Roadmap).
 
 ## 📦 Installation
 

--- a/gin/middleware.go
+++ b/gin/middleware.go
@@ -21,20 +21,26 @@ func RateLimiter(config rrl.HTTPRateLimiterConfig) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		key := config.KeyFunc(c.Request)
 
-		if !config.Limiter.IsRequestAllowed(key) {
-			log.Printf("Rate limit exceeded for key: %s", key)
-			c.Header(rrl.HeaderRateLimit, strconv.FormatInt(config.Limiter.MaxTokens, 10))
-			c.Header(rrl.HeaderRateLimitRemaining, strconv.FormatInt(config.Limiter.CurrentToken, 10))
-			// Actually currentToken is unexported 'currentToken'.
-			// We cannot access 'config.Limiter.currentToken' from here if it is lowercase.
-			// Problem: 'currentToken' in 'RateLimiter' struct is lowercase.
-			// Fix: I need to export 'CurrentToken' or added a Getter in the root package.
-			// OR I can ignore the header for now or rely on IsRequestAllowed changing?
-			// IsRequestAllowed returned 'bool'.
-			// The new Lua implementation returns 'remaining'.
-			// IsRequestAllowed implementation currently returns 'bool'.
-			// I should verify 'limiter.go' again. I wrote it in Step 40.
+		// Check rate limit
+		result, err := config.Limiter.Allow(c.Request.Context(), key)
+		if err != nil {
+			log.Printf("Rate limit error: %v", err)
+			// Fail open or closed depending on requirements?
+			// Assuming fail closed or open? Original failed closed if Store error in IsRequestAllowed.
+			// Let's match original behavior: if store error, we treated as not allowed (IsRequestAllowed returned false).
+			// But IsRequestAllowed now returns false on error.
+			// Let's handle it gracefully.
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "rate limit error"})
+			c.Abort()
+			return
+		}
 
+		c.Header(rrl.HeaderRateLimit, strconv.FormatInt(config.Limiter.MaxTokens, 10))
+		c.Header(rrl.HeaderRateLimitRemaining, strconv.FormatInt(result.Remaining, 10))
+		c.Header(rrl.HeaderRateLimitRetryAfter, strconv.FormatInt(int64(result.RetryAfter.Seconds()), 10))
+
+		if !result.Allowed {
+			log.Printf("Rate limit exceeded for key: %s", key)
 			c.JSON(http.StatusTooManyRequests, gin.H{"error": "too many requests"})
 			c.Abort()
 			return


### PR DESCRIPTION
### **What's new?**
**Critical Fixes Implemented ✅**
1. **Data Race** in `RateLimiter` `(limiter.go)`
**Issue:** The `RateLimiter` struct utilized a shared field `CurrentToken` to cache the remaining tokens for header generation. This caused data races when accessed by concurrent requests.
**Fix:** Removed the stateful `CurrentToken` field. Refactored the API to `Allow(ctx, key) (*Result, error)`, which returns the Remaining count and RetryAfter duration atomically from the store.
**Impact:** The rate limiter is now fully thread-safe.
2. **Circuit Breaker Concurrency Flaw** `(circuit_breaker_store.go)`
**Issue:** In the `Half-Open` state, the circuit breaker allowed concurrent requests to "probe" the backend simultaneously if they arrived at the same time. This could allow bursts of traffic to hit a recovering backend, defeating the purpose of the circuit breaker.
**Fix:** Implemented a `probing` atomic flag (via mutex) to ensure only one request acts as the probe. All other concurrent requests fail fast while a probe is in flight.
**Impact:** Strict enforcement of the **Half-Open** protocol, better protection for recovering backends.
### 

**Code Quality & Performance Findings**
1. Performance: Random ID Generation
**Observation:** The `RedisSlidingWindowStore` uses `crypto/rand` to generate a unique request ID for every check.
```
// redis_sliding_window_store.go
rand.Reader // used in generateRandomID()
```
**Impact:** `crypto/rand` is relatively slow compared to other operations. For a high-throughput rate limiter, this adds unnecessary overhead.
**Recommendation:** Since security is not the primary concern for this ID (it just needs to be unique within the millisecond window), consider switching to `math/rand/v2` (Go 1.22+) or a fast UUID generator for better performance in future releases.
2. Code Quality
**MemoryStore:** Verified to be thread-safe with proper sync.Mutex usage.
**Middleware:** Successfully updated to use the new thread-safe Allow API.

**### API Changes**
**Deprecated:** `IsRequestAllowed(key)` is deprecated.
**New:** `Allow(ctx, key)` is the recommended method.