### PR TITLE
chore: support Go 1.26

### DIFF
--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.23' ]
+        go-version: [ '1.23', '1.26' ]
     services:
       redis:
         image: redis:latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.23'
+        go-version: '1.26'
 
     - name: Start Redis
       uses: supercharge/redis-github-action@1.7.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nccapo/rate-limiter
 
-go 1.23
+go 1.26
 
 require (
 	github.com/alicebob/miniredis/v2 v2.34.0


### PR DESCRIPTION
This PR updates the package to officially support Go version 1.26.

### Changes
- Updated the minimum Go version to `1.26` in `go.mod`.
- Expanded the matrix in `.github/workflows/build-go.yaml` to run tests on both `1.23` and `1.26` toolchains.
- Updated the Go setup version in `.github/workflows/go.yml` to `1.26`.

All local tests pass successfully.